### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: acorn-io/actions-setup@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 on:
   push:
     branches:
@@ -8,15 +8,13 @@ on:
       - main
 
 jobs:
-  publish:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20
-      - run: make setup-ci-env
-      - run: make validate-ci
+          go-version: 1.20.2
       - run: make validate
       - run: make build
       - name: Test


### PR DESCRIPTION
Noticed that the actions were unable to use buildjet. Switching to GitHub runners.

Reference - https://github.com/acorn-io/acorn-istio-plugin/actions/runs/4566828641

Additionally, update some small things about CI to be clearer.