### PR TITLE
Replace finalizer with better garbage collection

### DIFF
--- a/pkg/controller/gc.go
+++ b/pkg/controller/gc.go
@@ -1,0 +1,14 @@
+package controller
+
+import (
+	"github.com/acorn-io/baaah/pkg/apply"
+	"github.com/acorn-io/baaah/pkg/router"
+)
+
+func GCOrphans(req router.Request, resp router.Response) error {
+	if !req.Object.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	return apply.New(req.Client).PurgeOrphan(req.Ctx, req.Object)
+}

--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -28,6 +28,7 @@ const (
 	acornAppNameLabel       = "acorn.io/app-name"
 	acornProjectNameLabel   = "acorn.io/app-namespace"
 	acornContainerNameLabel = "acorn.io/container-name"
+	acornManagedLabel       = "acorn.io/managed"
 
 	masterLabel = "on-master"
 
@@ -122,6 +123,9 @@ func (h Handler) PoliciesForApp(req router.Request, resp router.Response) error 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName(appNamespace.Name, "strict"),
 			Namespace: appNamespace.Name,
+			Labels: map[string]string{
+				acornManagedLabel: "true",
+			},
 		},
 		Spec: v1beta1.PeerAuthentication{
 			Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -154,6 +158,9 @@ func (h Handler) PoliciesForApp(req router.Request, resp router.Response) error 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName(appNamespace.Name, "authorization"),
 			Namespace: appNamespace.Name,
+			Labels: map[string]string{
+				acornManagedLabel: "true",
+			},
 		},
 		Spec: v1beta1.AuthorizationPolicy{
 			Rules: []*v1beta1.Rule{{
@@ -272,6 +279,9 @@ func (h Handler) PoliciesForIngress(req router.Request, resp router.Response) er
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      policyName,
 				Namespace: svc.Namespace,
+				Labels: map[string]string{
+					acornManagedLabel: "true",
+				},
 			},
 			Spec: v1beta1.PeerAuthentication{
 				Selector: &typev1beta1.WorkloadSelector{
@@ -288,6 +298,9 @@ func (h Handler) PoliciesForIngress(req router.Request, resp router.Response) er
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      policyName,
 				Namespace: svc.Namespace,
+				Labels: map[string]string{
+					acornManagedLabel: "true",
+				},
 			},
 			Spec: v1beta1.AuthorizationPolicy{
 				Selector: &typev1beta1.WorkloadSelector{
@@ -348,6 +361,9 @@ func (h Handler) PoliciesForService(req router.Request, resp router.Response) er
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyName,
 			Namespace: service.Namespace,
+			Labels: map[string]string{
+				acornManagedLabel: "true",
+			},
 		},
 		Spec: v1beta1.PeerAuthentication{
 			Selector: &typev1beta1.WorkloadSelector{
@@ -364,6 +380,9 @@ func (h Handler) PoliciesForService(req router.Request, resp router.Response) er
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyName,
 			Namespace: service.Namespace,
+			Labels: map[string]string{
+				acornManagedLabel: "true",
+			},
 		},
 		Spec: v1beta1.AuthorizationPolicy{
 			Selector: &typev1beta1.WorkloadSelector{

--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/acorn-io/baaah/pkg/router"
+	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -56,7 +57,8 @@ func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugIma
 	router.Type(&corev1.Namespace{}).Selector(projectSelector).HandlerFunc(AddLabels)
 	router.Type(&corev1.Namespace{}).Selector(appNamespaceSelector).HandlerFunc(h.PoliciesForApp)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(h.PoliciesForIngress)
-	router.Type(&netv1.Ingress{}).Selector(managedSelector).FinalizeFunc("acorn.io/istio", h.PoliciesForIngress)
+	router.Type(&securityv1beta1.PeerAuthentication{}).Selector(managedSelector).HandlerFunc(GCOrphans)
+	router.Type(&securityv1beta1.AuthorizationPolicy{}).Selector(managedSelector).HandlerFunc(GCOrphans)
 	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(h.PoliciesForService)
 	router.Type(&corev1.Pod{}).Selector(managedSelector).Selector(jobSelector).HandlerFunc(h.KillIstioSidecar)
 	router.Type(&corev1.Pod{}).Selector(istiodSelector).Namespace(istioSystemNamespace).HandlerFunc(LabelIstiodPod)

--- a/pkg/controller/testdata/app/expected.yaml
+++ b/pkg/controller/testdata/app/expected.yaml
@@ -4,6 +4,8 @@ kind: PeerAuthentication
 metadata:
   name: foo-strict
   namespace: foo
+  labels:
+    acorn.io/managed: "true"
 spec:
   mtls:
     mode: STRICT
@@ -13,6 +15,8 @@ kind: AuthorizationPolicy
 metadata:
   name: foo-authorization
   namespace: foo
+  labels:
+    acorn.io/managed: "true"
 spec:
   rules:
     - from:

--- a/pkg/controller/testdata/externalname/expected.yaml
+++ b/pkg/controller/testdata/externalname/expected.yaml
@@ -4,6 +4,8 @@ kind: PeerAuthentication
 metadata:
   name: acorn-my-app-service-7777-service-7777
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   portLevelMtls:
     "9999":
@@ -21,6 +23,8 @@ kind: AuthorizationPolicy
 metadata:
   name: acorn-my-app-service-7777-service-7777
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   rules:
     - from:

--- a/pkg/controller/testdata/ingress/expected.yaml
+++ b/pkg/controller/testdata/ingress/expected.yaml
@@ -4,6 +4,8 @@ kind: PeerAuthentication
 metadata:
   name: acorn-my-app-my-service-service-7777
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   portLevelMtls:
     "9999":
@@ -23,6 +25,8 @@ kind: PeerAuthentication
 metadata:
   name: acorn-my-app-my-service-nginx-9090
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   portLevelMtls:
     "9090":
@@ -40,6 +44,8 @@ kind: AuthorizationPolicy
 metadata:
   name: acorn-my-app-my-service-service-7777
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   rules:
     - from:
@@ -64,6 +70,8 @@ kind: AuthorizationPolicy
 metadata:
   name: acorn-my-app-my-service-nginx-9090
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   rules:
     - from:

--- a/pkg/controller/testdata/service/expected.yaml
+++ b/pkg/controller/testdata/service/expected.yaml
@@ -4,6 +4,8 @@ kind: PeerAuthentication
 metadata:
   name: acorn-my-app-one-publish-one
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   portLevelMtls:
     "8080":
@@ -24,6 +26,8 @@ kind: AuthorizationPolicy
 metadata:
   name: acorn-my-app-one-publish-one
   namespace: my-app-namespace
+  labels:
+    acorn.io/managed: "true"
 spec:
   rules:
     - from:


### PR DESCRIPTION
Using the same strategy here that we did in Acorn to clean up NetworkPolicies.