### PR TITLE
Fix a couple problems in the acornfile

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -1,12 +1,17 @@
 args: {
 	// List of namespaces that must send traffic to all Acorn apps (comma separated)
 	allowTrafficFromNamespaces: ""
+	// Image to use to kill Istio sidecars (must have curl installed)
+	debugImage: "ghcr.io/acorn-io/acorn-istio-plugin:main"
+}
+
+profiles: dev: {
+    debugImage: "curlimages/curl"
 }
 
 containers: "istio-plugin-controller": {
 	build: "."
-	env: IMAGE: "${secret://image/image}"
-	command: ["--debug-image", "$(IMAGE)", "--allow-traffic-from-namespaces", args.allowTrafficFromNamespaces]
+	command: ["--debug-image", args.debugImage, "--allow-traffic-from-namespaces", args.allowTrafficFromNamespaces]
 	permissions: clusterRules: [
 		{
 			verbs: ["list", "get", "patch", "update", "watch"]
@@ -31,7 +36,7 @@ containers: "istio-plugin-controller": {
 		{
 			verbs: ["*"]
 			apiGroups: ["security.istio.io"]
-			resources: ["peerauthentications", "authorizationpolicies"]
+			resources: ["peerauthentications", "peerauthentications/status", "authorizationpolicies", "authorizationpolicies/status"]
 		},
 		{
 			verbs: ["list", "get", "watch", "update"]
@@ -49,9 +54,4 @@ containers: "istio-plugin-controller": {
 			resources: ["nodes"]
 		},
 	]
-}
-
-secrets: image: {
-	type: "template"
-	data: image: "${image://debug}"
 }

--- a/Acornfile
+++ b/Acornfile
@@ -2,7 +2,7 @@ args: {
 	// List of namespaces that must send traffic to all Acorn apps (comma separated)
 	allowTrafficFromNamespaces: ""
 	// Image to use to kill Istio sidecars (must have curl installed)
-	debugImage: "ghcr.io/acorn-io/acorn-istio-plugin:main"
+	debugImage: "ghcr.io/acorn-io/acorn-istio-plugin:prod"
 }
 
 profiles: dev: {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run the plugin with Acorn:
 
 ```shell
 # dev mode:
-acorn run --name acorn-istio-plugin --profile dev -i .
+acorn run --name acorn-istio-plugin -i .
 
 # latest main build:
 acorn run --name acorn-istio-plugin ghcr.io/acorn-io/acorn-istio-plugin:main

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run the plugin with Acorn:
 
 ```shell
 # dev mode:
-acorn run --name acorn-istio-plugin -i .
+acorn run --name acorn-istio-plugin --profile dev -i .
 
 # latest main build:
 acorn run --name acorn-istio-plugin ghcr.io/acorn-io/acorn-istio-plugin:main


### PR DESCRIPTION
This fixes two main issues in the Acornfile:
- The debugImage parameter was not being set properly before this. We should just default to the prod image unless running locally, where we can just use the official curl image from Docker Hub (this is to avoid architecture incompatibility, since our prod images only run on x86_64).
- The logs of the plugin were complaining that they could not update the statuses of PeerAuthentications and AuthorizationPolicies, so I added that to the default permissions.