### PR TITLE
Switch back to old method for debug image

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -1,17 +1,14 @@
 args: {
 	// List of namespaces that must send traffic to all Acorn apps (comma separated)
 	allowTrafficFromNamespaces: ""
-	// Image to use to kill Istio sidecars (must have curl installed)
-	debugImage: "ghcr.io/acorn-io/acorn-istio-plugin:prod"
-}
-
-profiles: dev: {
-    debugImage: "curlimages/curl"
 }
 
 containers: "istio-plugin-controller": {
 	build: "."
-	command: ["--debug-image", args.debugImage, "--allow-traffic-from-namespaces", args.allowTrafficFromNamespaces]
+	env: {
+        IMAGE: "${secret://image/image}"
+    }
+	command: ["--debug-image", "$(IMAGE)", "--allow-traffic-from-namespaces", args.allowTrafficFromNamespaces]
 	permissions: clusterRules: [
 		{
 			verbs: ["list", "get", "patch", "update", "watch"]
@@ -54,4 +51,21 @@ containers: "istio-plugin-controller": {
 			resources: ["nodes"]
 		},
 	]
+}
+
+secrets: {
+	image: {
+		type: "template"
+		data: {
+			image: "${image://debug}"
+		}
+	}
+}
+
+images: {
+    debug: {
+        containerBuild: {
+            context: "."
+        }
+    }
 }


### PR DESCRIPTION
I think this finally works. It will use the same image that is running the acorn-istio-plugin to also kill the sidecars.