### PR TITLE
Add new handler to create a VirtualService for linked Acorn apps

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -33,7 +33,12 @@ containers: "istio-plugin-controller": {
 		{
 			verbs: ["*"]
 			apiGroups: ["security.istio.io"]
-			resources: ["peerauthentications", "authorizationpolicies"]
+			resources: ["peerauthentications", "peerauthentications/status", "authorizationpolicies", "authorizationpolicies/status"]
+		},
+		{
+		    verbs: ["*"],
+		    apiGroups: ["networking.istio.io"]
+		    resources: ["virtualservices", "virtualservices/status"]
 		},
 		{
 			verbs: ["list", "get", "watch", "update"]
@@ -49,6 +54,11 @@ containers: "istio-plugin-controller": {
 			verbs: ["list", "get"]
 			apiGroups: [""]
 			resources: ["nodes"]
+		},
+		{
+		    verbs: ["list", "get", "watch"]
+		    apiGroups: ["internal.acorn.io"]
+		    resources: ["serviceinstances"]
 		},
 	]
 }

--- a/pkg/controller/handlers_test.go
+++ b/pkg/controller/handlers_test.go
@@ -65,16 +65,17 @@ func TestHandler_PoliciesForApp(t *testing.T) {
 }
 
 func TestHandler_PoliciesForIngress(t *testing.T) {
-	h := Handler{}
-	tester.DefaultTest(t, scheme.Scheme, "testdata/ingress", h.PoliciesForIngress)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/ingress", PoliciesForIngress)
 }
 
 func TestHandler_PoliciesForIngressExternalName(t *testing.T) {
-	h := Handler{}
-	tester.DefaultTest(t, scheme.Scheme, "testdata/externalname", h.PoliciesForIngress)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/externalname", PoliciesForIngress)
 }
 
 func TestHandler_PoliciesForService(t *testing.T) {
-	h := Handler{}
-	tester.DefaultTest(t, scheme.Scheme, "testdata/service", h.PoliciesForService)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/service", PoliciesForService)
+}
+
+func TestHandler_VirtualServiceForLink(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/link", VirtualServiceForLink)
 }

--- a/pkg/controller/testdata/link/expected.yaml
+++ b/pkg/controller/testdata/link/expected.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  labels:
+    acorn.io/managed: "true"
+  name: linked-hostname
+  namespace: test
+spec:
+  hosts:
+    - linked-hostname
+  http:
+    - route:
+        - destination:
+            host: other-app-container.other-app-namespace.svc.cluster.local
+            port:
+              number: 8080

--- a/pkg/controller/testdata/link/input.yaml
+++ b/pkg/controller/testdata/link/input.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    acorn.io/link-name: other-app
+  name: linked-hostname
+  namespace: test
+spec:
+  externalName: other-app-container.other-app-namespace.svc.cluster.local
+  ports:
+    - appProtocol: HTTP
+      name: "8080"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  type: ExternalName

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -2,6 +2,7 @@ package scheme
 
 import (
 	"github.com/rancher/wrangler/pkg/merr"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authorization/v1"
@@ -33,6 +34,7 @@ func AddToScheme(scheme *runtime.Scheme) error {
 	errs = append(errs, authv1.AddToScheme(scheme))
 	errs = append(errs, apiextensionv1.AddToScheme(scheme))
 	errs = append(errs, securityv1beta1.AddToScheme(scheme))
+	errs = append(errs, networkingv1beta1.AddToScheme(scheme))
 	return merr.NewErrors(errs...)
 }
 


### PR DESCRIPTION
When an Acorn app links to another Acorn app, Acorn creates an ExternalName Service to basically create a hostname alias. This was not working for non-published ports because Istio did not know how to do mTLS when this was happening, so all connections were getting denied. By creating a VirtualService, we basically create the same hostname alias in a way that Istio understands so it can still do mTLS between the containers.

This PR depends on https://github.com/acorn-io/acorn/pull/1529.