### PR TITLE
Remove unneeded handler

### DIFF
--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -19,13 +19,6 @@ var (
 		"acorn.io/managed": "true",
 	})
 
-	istiodSelector = labels.SelectorFromSet(map[string]string{
-		"app":   "istiod",
-		"istio": "pilot",
-	})
-
-	istioSystemNamespace = "istio-system"
-
 	appNameLabel      = "acorn.io/app-name"
 	appNamespaceLabel = "acorn.io/app-namespace"
 	jobLabel          = "acorn.io/job-name"
@@ -67,7 +60,6 @@ func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugIma
 	router.Type(&securityv1beta1.AuthorizationPolicy{}).Selector(managedSelector).HandlerFunc(GCOrphans)
 	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(PoliciesForService)
 	router.Type(&corev1.Pod{}).Selector(managedSelector).Selector(jobSelector).HandlerFunc(h.KillIstioSidecar)
-	router.Type(&corev1.Pod{}).Selector(istiodSelector).Namespace(istioSystemNamespace).HandlerFunc(LabelIstiodPod)
 	router.Type(&corev1.Service{}).Selector(linkSelector).HandlerFunc(VirtualServiceForLink)
 	return nil
 }


### PR DESCRIPTION
This handler was responsible for putting `on-master: <true/false>` labels on Istiod pods. We don't need this anymore since we improved how we deploy Istio and no longer need to rely on these labels.