### PR TITLE
Don't assume a port always exists

### DIFF
--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -413,7 +413,7 @@ func VirtualServiceForLink(req router.Request, resp router.Response) error {
 	service := req.Object.(*corev1.Service)
 
 	// the link label shouldn't be present on any non-ExternalName type Services, but check anyway
-	if service.Spec.Type != corev1.ServiceTypeExternalName {
+	if service.Spec.Type != corev1.ServiceTypeExternalName || len(service.Spec.Ports) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
There are transient situations in which an external name is created
and there are not ports on that external name. For now we should just
ignore those services.
