### PR TITLE
Set log level to error

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ var (
 func main() {
 	flag.Parse()
 
+	logrus.SetLevel(logrus.ErrorLevel)
+
 	fmt.Printf("Version: %s\n", version.Get())
 	if *versionFlag {
 		return


### PR DESCRIPTION
For some reason, bumping the baaah dependency leads to panics caused by bad DeepCopy methods for some of Istio's API types? It's very weird.

This just sets the logrus log level to error (since the info and warning logs are usually not useful/interesting anyway) so that we spam way less.