### PR TITLE
Ignore ingress for Acorn DNS

### DIFF
--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -26,7 +26,6 @@ var (
 )
 
 func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugImage, allowTrafficFromNamespaces string) error {
-
 	h := Handler{
 		client:                     client,
 		debugImage:                 debugImage,


### PR DESCRIPTION
When we switched to creating a wildcard record for each cluster, we started creating an Ingress resource specifically for Acorn DNS (that doesn't actually expose any pods). The plugin was finding it and trying to create stuff for it and logging errors. This fixes that.