### PR TITLE
Add air

### DIFF
--- a/.air-template.toml
+++ b/.air-template.toml
@@ -1,0 +1,44 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = "dlv exec --continue --accept-multiclient --listen=:2345 --headless=true --api-version=2 --log ./tmp/main -- --debug-image %IMAGE%"
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "1s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  rerun = true
+  rerun_delay = 1000
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/Acornfile
+++ b/Acornfile
@@ -1,12 +1,11 @@
-args: {
-	// List of namespaces that must send traffic to all Acorn apps (comma separated)
-	allowTrafficFromNamespaces: ""
-}
-
 containers: "istio-plugin-controller": {
-	build: "."
-	env: IMAGE: "${secret://image/image}"
-	command: ["--debug-image", "$(IMAGE)", "--allow-traffic-from-namespaces", args.allowTrafficFromNamespaces]
+	localData.airConfig
+	env: {
+		IMAGE: "${secret://image/image}"
+	}
+	if !args.dev {
+		command: ["--debug-image", "$(IMAGE)"]
+	}
 	permissions: clusterRules: [
 		{
 			verbs: ["list", "get", "patch", "update", "watch"]
@@ -62,3 +61,14 @@ secrets: image: {
 }
 
 images: debug: containerBuild: context: "."
+
+localData: airConfig: {
+	build: target: std.ifelse(args.dev, "dev", "base")
+	if args.dev {
+		dirs: {
+			"/app":                  "./"
+			"/go/pkg":               "volume://go-cache?subpath=pkg"
+			"/root/.cache/go-build": "volume://go-cache?subpath=cache"
+		}
+	}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM golang as dev
+RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+ENV PATH=/root/go/bin:$PATH
+WORKDIR "/app"
+ENTRYPOINT ["bash", "air.sh"]
+
 FROM golang:1.20 AS build
 COPY / /src
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ This plugin is responsible for the following:
 make build
 ```
 
-## Args
-
-- `--allow-traffic-from-namespaces`: list of namespaces to allow to connect to all Acorn apps as a single string, comma separated
-  - example: `--allow-traffic-from-namespaces "monitoring,kube-system"`
-
 ## Prerequisites
 
 Your local Kubernetes cluster needs to have Acorn installed with the following options at a minimum:

--- a/air.sh
+++ b/air.sh
@@ -1,0 +1,3 @@
+# ${IMAGE//\//\\/} is needed to escape all of the forward slashes in IMAGE
+sed "s/%IMAGE%/${IMAGE//\//\\/}/g" .air-template.toml > .air.toml
+exec air -c .air.toml

--- a/main.go
+++ b/main.go
@@ -16,10 +16,8 @@ import (
 )
 
 var (
-	versionFlag                = flag.Bool("version", false, "print version and exit")
-	debugImageFlag             = flag.String("debug-image", "ghcr.io/acorn-io/acorn-istio-plugin:main", "Container image used to kill Istio sidecars (needs to have curl installed)")
-	allowTrafficFromNamespaces = flag.String("allow-traffic-from-namespaces", "", `Extra namespaces that should be allowed to send traffic to all Acorn apps (comma-separated).
-								Pods in these namespaces must be part of the Istio service mesh in order to send traffic.`)
+	versionFlag    = flag.Bool("version", false, "print version and exit")
+	debugImageFlag = flag.String("debug-image", "ghcr.io/acorn-io/acorn-istio-plugin:main", "Container image used to kill Istio sidecars (needs to have curl installed)")
 )
 
 func main() {
@@ -44,9 +42,8 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 	if err := controller.Start(ctx, controller.Options{
-		K8s:                        k8s,
-		DebugImage:                 *debugImageFlag,
-		AllowTrafficFromNamespaces: *allowTrafficFromNamespaces,
+		K8s:        k8s,
+		DebugImage: *debugImageFlag,
 	}); err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -9,9 +9,8 @@ import (
 )
 
 type Options struct {
-	K8s                        kubernetes.Interface
-	DebugImage                 string
-	AllowTrafficFromNamespaces string
+	K8s        kubernetes.Interface
+	DebugImage string
 }
 
 func Start(ctx context.Context, opt Options) error {
@@ -20,7 +19,7 @@ func Start(ctx context.Context, opt Options) error {
 		return err
 	}
 
-	if err := RegisterRoutes(router, opt.K8s, opt.DebugImage, opt.AllowTrafficFromNamespaces); err != nil {
+	if err := RegisterRoutes(router, opt.K8s, opt.DebugImage); err != nil {
 		return err
 	}
 

--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -34,9 +34,8 @@ const (
 )
 
 type Handler struct {
-	client                     kubernetes.Interface
-	debugImage                 string
-	allowTrafficFromNamespaces string
+	client     kubernetes.Interface
+	debugImage string
 }
 
 // AddLabels adds the "istio-injection: enabled" label on every Acorn project namespace
@@ -109,7 +108,7 @@ func (h Handler) KillIstioSidecar(req router.Request, resp router.Response) erro
 // PoliciesForApp creates an Istio PeerAuthentication in each app's namespace.
 // The PeerAuthentication sets mTLS to STRICT mode, meaning that all pods in the namespace will only
 // accept incoming network traffic from other pods in the Istio mesh.
-func (h Handler) PoliciesForApp(req router.Request, resp router.Response) error {
+func PoliciesForApp(req router.Request, resp router.Response) error {
 	appNamespace := req.Object.(*corev1.Namespace)
 
 	// Create the PeerAuthentication to set entire app to mTLS STRICT mode by default

--- a/pkg/controller/handlers_test.go
+++ b/pkg/controller/handlers_test.go
@@ -58,8 +58,7 @@ func TestHandler_KillIstioSidecar(t *testing.T) {
 }
 
 func TestHandler_PoliciesForApp(t *testing.T) {
-	h := Handler{}
-	tester.DefaultTest(t, scheme.Scheme, "testdata/app", h.PoliciesForApp)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/app", PoliciesForApp)
 }
 
 func TestHandler_PoliciesForIngress(t *testing.T) {

--- a/pkg/controller/handlers_test.go
+++ b/pkg/controller/handlers_test.go
@@ -58,9 +58,7 @@ func TestHandler_KillIstioSidecar(t *testing.T) {
 }
 
 func TestHandler_PoliciesForApp(t *testing.T) {
-	h := Handler{
-		allowTrafficFromNamespaces: "monitoring",
-	}
+	h := Handler{}
 	tester.DefaultTest(t, scheme.Scheme, "testdata/app", h.PoliciesForApp)
 }
 

--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -25,11 +25,10 @@ var (
 	linkLabel         = "acorn.io/link-name"
 )
 
-func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugImage, allowTrafficFromNamespaces string) error {
+func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugImage string) error {
 	h := Handler{
-		client:                     client,
-		debugImage:                 debugImage,
-		allowTrafficFromNamespaces: allowTrafficFromNamespaces,
+		client:     client,
+		debugImage: debugImage,
 	}
 
 	managedSelector, err := getAcornManagedSelector()
@@ -53,7 +52,7 @@ func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugIma
 	}
 
 	router.Type(&corev1.Namespace{}).Selector(projectSelector).HandlerFunc(AddLabels)
-	router.Type(&corev1.Namespace{}).Selector(appNamespaceSelector).HandlerFunc(h.PoliciesForApp)
+	router.Type(&corev1.Namespace{}).Selector(appNamespaceSelector).HandlerFunc(PoliciesForApp)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(PoliciesForIngress)
 	router.Type(&securityv1beta1.PeerAuthentication{}).Selector(managedSelector).HandlerFunc(GCOrphans)
 	router.Type(&securityv1beta1.AuthorizationPolicy{}).Selector(managedSelector).HandlerFunc(GCOrphans)


### PR DESCRIPTION
I also removed the `--allow-traffic-from-namespaces` argument from the Acorn, as it is no longer needed (since the plugin no longer does anything with AuthorizationPolicies).